### PR TITLE
Fix commit message for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
             "package-lock.json",
             "CHANGELOG.md"
           ],
-          "message": "release(version): Release ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+          "message": "chore(version): release ${nextRelease.version} [skip ci]"
         }
       ],
       "@semantic-release/github"


### PR DESCRIPTION
## Description
This pull request makes a minor update to the commit message used during the release process in `package.json`. The release commit message is now shorter and no longer includes the release notes.
